### PR TITLE
cleaned up interact event

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/event/UseEntity.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/event/UseEntity.kt
@@ -23,29 +23,17 @@ object UseEntity {
         hitResult: EntityHitResult?
     ): ActionResult {
         if (entity !is PokemonEntity) return ActionResult.PASS
-        if (!entity.pokemon.isWild()) {
+        if (!entity.pokemon.isWild() || world.isClient) {
             return ActionResult.PASS
         }
         if (!player.getEquippedStack(EquipmentSlot.MAINHAND).isEmpty) {
             return ActionResult.PASS
         }
-        if (!world.isClient) {
-            val species = entity.pokemon.species.name.lowercase(Locale.getDefault())
-            val alreadyEncountered = EncounterApi.check(player, species)
-            if (alreadyEncountered) {
-                if (config.broadcastEncountersToPlayer) {
-                    val alreadyCaught = CaptureApi.getCount(player, species) > 0
-                    player.sendMessage(
-                        Text.translatable(
-                            if (alreadyCaught) "counter.encounter.alreadyCaught" else "counter.encounter.alreadyEncountered",
-                            species
-                        )
-                    )
-                }
-            } else {
-                EncounterApi.add(player, species)
-            }
+        val species = entity.pokemon.species.name.lowercase(Locale.getDefault())
+        val alreadyEncountered = EncounterApi.check(player, species)
+        if (!alreadyEncountered) {
+            EncounterApi.add(player, species)
         }
-        return ActionResult.SUCCESS
+        return ActionResult.PASS
     }
 }

--- a/src/main/resources/assets/cobblemon_counter/lang/en_us.json
+++ b/src/main/resources/assets/cobblemon_counter/lang/en_us.json
@@ -14,7 +14,6 @@
     "counter.capture.confirm": "Captured %d (%d/%d)",
     "counter.ko.confirm": "KO'd %d (%d/%d)",
     "counter.encounter.confirm": "You've encountered a %d for the first time",
-    "counter.encounter.alreadyEncountered": "You've already encountered a %d",
     "counter.encounter.alreadyCaught": "You've already caught a %d",
     "counter.encounter.total": "%d has encountered %d total Pokemon",
     "counter.encounter.all.reset": "Encounter data reset for %d",


### PR DESCRIPTION
no more telling the player if they've already encountered; that was firing multiple times on one click despite ditching out if client.
always return pass so it doesn't consume the click. apparently client doesn't know if wild or not and always returns false?
fix #18
